### PR TITLE
Add LITE services except "data-flow".

### DIFF
--- a/logstash-sentinel/pipelines/sentinel.conf
+++ b/logstash-sentinel/pipelines/sentinel.conf
@@ -87,7 +87,7 @@ filter {
         }
     }
 
-    if [cf][app] != "staff-sso" and [cf][space] != "market-access" and [cf][app] != "datahub-api" and [cf][app] != "digital-workspace-v2" {
+    if [cf][app] != "staff-sso" and [cf][space] != "market-access" and [cf][app] != "datahub-api" and [cf][app] != "digital-workspace-v2" and [cf][app] != "lite-hmrc" and [cf][app] != "lite-api" and [cf][app] != "lite-exporter-frontend" and [cf][app] != "lite-internal-frontend" {
       drop { }
     }
 }


### PR DESCRIPTION
Adds the following LITE apps to the Sentinel filter config:
- lite-hmrc
- lite-api
- lite-exporter-frontend
- lite-internal-frontend