### PR TITLE
Sentinel cloudfront logs

### DIFF
--- a/filebeat-s3-logstash/Dockerfile
+++ b/filebeat-s3-logstash/Dockerfile
@@ -1,0 +1,9 @@
+FROM docker.elastic.co/beats/filebeat:7.17.5
+
+COPY filebeat.yml /usr/share/filebeat/filebeat.yml
+
+USER root
+RUN chown root:filebeat /usr/share/filebeat/filebeat.yml
+RUN chmod go-w /usr/share/filebeat/filebeat.yml
+
+USER filebeat

--- a/filebeat-s3-logstash/filebeat.yml
+++ b/filebeat-s3-logstash/filebeat.yml
@@ -1,0 +1,18 @@
+filebeat.inputs:
+- type: aws-s3
+  queue_url: "${FILEBEAT_INPUT_QUEUE_URL}"
+  number_of_workers: "${FILEBEAT_INPUT_WORKERS}"
+  parsers:
+  - multiline:
+      type: pattern
+      pattern: '^#'
+      negate: false
+      match: before
+
+output.logstash:
+  hosts: ["${FILEBEAT_OUTPUT_HOST}"]
+  ttl: "${FILEBEAT_OUTPUT_TTL}"
+  pipelining: "${FILEBEAT_OUTPUT_PIPELINING}"
+
+logging.metrics.enabled: false
+monitoring.enabled: false

--- a/logstash-s3-prune/Dockerfile
+++ b/logstash-s3-prune/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10.6
+
+RUN pip install boto3
+
+COPY s3_prune.py .
+
+CMD ["python3","s3_prune.py"]

--- a/logstash-s3-prune/README.md
+++ b/logstash-s3-prune/README.md
@@ -1,0 +1,26 @@
+# logstash-s3-prune
+This container image is used to prune an S3 bucket of log file objects, based on messages posted in an SQS queue. The intention is to post messages to the queue from a Logstash output (once the file is processed).  
+Note that the SQS queue name must be specified, but the S3 bucket is not. This is read from the SQS message.  
+The task or container running the script must have appropriate IAM permissions to read the queue and delete from the bucket and the queue - see below.  
+The queue and bucket are assumed to be in the same region.  
+An exponential backoff increases exponentially (up to a max limit) if the queue is empty. See env vars.
+
+## Environment Variables
+| Variable    | Description | Required | Default |
+| ----------- | ----------- | -------- | ------- |
+| AWS_REGION | Region of the S3 bucket and SQS queue | Yes | (none) |
+| AWS_SQS_QUEUE | The name of the SQS queue to read | Yes | (none) |
+| SQS_BATCH_SIZE | Max number of messages to read per batch | No | 1 |
+| BACKOFF_SLEEP | Initial value of exponential backoff sleep | No | 1 |
+| MAX_BACKOFF_SLEEP | Max value of exponential backoff sleep | No | 32 |
+| LOG_LEVEL | Standard log level | No | INFO |
+
+## IAM Permissions
+SQS required permissions:
+- sqs:GetQueueUrl
+- sqs:ReceiveMessage
+- sqs:DeleteMessage
+
+S3 required permissions:
+- s3:ListBucket
+- s3:DeleteObject

--- a/logstash-s3-prune/s3_prune.py
+++ b/logstash-s3-prune/s3_prune.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import json
+import time
+import logging
+
+import boto3
+
+# Initialise logging
+logger = logging.getLogger("S3-PURGE")
+logger.setLevel(
+    os.environ.get("LOG_LEVEL", "INFO").upper()
+    )
+stdout_handler = logging.StreamHandler(stream=sys.stdout)
+logger.addHandler(stdout_handler)
+
+# Initialise AWS resources
+s3 = boto3.resource("s3", region_name=os.environ.get("AWS_REGION"))
+sqs = boto3.resource("sqs", region_name=os.environ.get("AWS_REGION"))
+queue = sqs.get_queue_by_name(QueueName=os.environ.get("AWS_SQS_QUEUE"))
+logger.info(f"SQS Queue: {queue}")
+sqs_batch_size = int(os.environ.get("SQS_BATCH_SIZE", 1))
+logger.info(f"SQS Batch Size: {sqs_batch_size}")
+
+# Other initialisation
+backoff_sleep = int(os.environ.get("BACKOFF_SLEEP", 1))
+max_backoff_sleep = int(os.environ.get("MAX_BACKOFF_SLEEP", 32))
+
+# Process messages in infinite loop
+while True:
+
+    try:
+        # Read messages from SQS queue
+        messages = queue.receive_messages(MaxNumberOfMessages=sqs_batch_size)
+        message_len = len(messages)
+        logger.debug(f"Read {message_len} messages from queue.")
+        if message_len == 0:
+            logger.debug(f"No messages. Sleep {backoff_sleep}.")
+            time.sleep(backoff_sleep)
+            backoff_sleep = min(backoff_sleep * 2, max_backoff_sleep)
+            continue
+        backoff_sleep = int(os.environ.get("BACKOFF_SLEEP", 1))
+
+        # Process all messages
+        for message in messages:
+            message_json = json.loads(message.body)
+            logger.debug(f"Message JSON: {message_json}")
+            logger.info(f"Delete object {message_json['aws']['s3']['object']['key']} from bucket {message_json['aws']['s3']['bucket']['name']}")
+            # Delete object from S3
+            s3_delete = s3.Object(message_json['aws']['s3']['bucket']['name'], message_json['aws']['s3']['object']['key']).delete()
+            logger.info(f"S3 delete response: {s3_delete['ResponseMetadata']['HTTPStatusCode']}")
+            if s3_delete['ResponseMetadata']['HTTPStatusCode'] != 204:
+                logger.error(s3_delete['ResponseMetadata'])
+                continue
+            # Delete message from SQS
+            sqs_delete = message.delete()
+            logger.info(f"SQS delete response: {sqs_delete['ResponseMetadata']['HTTPStatusCode']}")
+            if sqs_delete['ResponseMetadata']['HTTPStatusCode'] != 200:
+                logger.error(sqs_delete['ResponseMetadata'])
+                continue
+
+    except Exception as ex:
+        logger.error("Exception: {0} {1!r}".format(type(ex).__name__, ex.args))
+        time.sleep(max_backoff_sleep)

--- a/logstash-sentinel-cloudfront/Dockerfile
+++ b/logstash-sentinel-cloudfront/Dockerfile
@@ -1,0 +1,19 @@
+FROM docker.elastic.co/logstash/logstash:7.17.5
+
+RUN cd /usr/share/logstash && \
+				bin/logstash-plugin install logstash-input-beats && \
+				bin/logstash-plugin install logstash-output-sqs && \
+				bin/logstash-plugin install logstash-output-opensearch && \
+				bin/logstash-plugin install microsoft-logstash-output-azure-loganalytics
+
+COPY logstash.yml /usr/share/logstash/config
+COPY entrypoint.sh /usr/share/logstash/bin/entrypoint.sh
+COPY pipelines/* /usr/share/logstash/config/pipelines/
+COPY pipelines.yml /usr/share/logstash/config/pipelines.yml
+USER root
+RUN chown logstash:logstash bin/entrypoint.sh && chmod 0750 bin/entrypoint.sh
+RUN chown logstash:logstash /usr/share/logstash/config/logstash.yml && chmod 0750 /usr/share/logstash/config/logstash.yml
+USER logstash
+
+ENTRYPOINT ["/bin/bash"]
+CMD ["/usr/share/logstash/bin/entrypoint.sh"]

--- a/logstash-sentinel-cloudfront/README.md
+++ b/logstash-sentinel-cloudfront/README.md
@@ -1,0 +1,2 @@
+# logstash-sentinel-cloudfront
+Logstash configuration for moving CloudFront logs to Sentinel via Filebeat.

--- a/logstash-sentinel-cloudfront/entrypoint.sh
+++ b/logstash-sentinel-cloudfront/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set +o history
+export LOGSTASH_KEYSTORE_PASS=mypassword
+set -o history
+bin/logstash-keystore create
+
+exec /usr/local/bin/docker-entrypoint

--- a/logstash-sentinel-cloudfront/logstash.yml
+++ b/logstash-sentinel-cloudfront/logstash.yml
@@ -1,0 +1,9 @@
+http.host: "127.0.0.1"
+
+# log.level: trace
+# config.debug: true
+
+dead_letter_queue.enable: false
+path.dead_letter_queue: "/usr/share/logstash/data/dead_letter_queue"
+
+pipeline.ecs_compatibility: disabled 

--- a/logstash-sentinel-cloudfront/pipelines.yml
+++ b/logstash-sentinel-cloudfront/pipelines.yml
@@ -1,0 +1,2 @@
+- pipeline.id: sentinel_cloudfront
+  path.config: "/usr/share/logstash/config/pipelines/sentinel_cloudfront.conf"

--- a/logstash-sentinel-cloudfront/pipelines/sentinel_cloudfront.conf
+++ b/logstash-sentinel-cloudfront/pipelines/sentinel_cloudfront.conf
@@ -1,0 +1,133 @@
+input {
+  beats {
+    host => "${LOGSTASH_BEATS_HOST:0.0.0.0}"
+    port => "${LOGSTASH_BEATS_PORT:5044}"
+    client_inactivity_timeout => "${LOGSTASH_BEATS_TIMEOUT:60}"
+  }
+}
+
+
+filter {
+
+  # Remove any initial Beats / Codec tags.
+  mutate {
+    remove_field => [ "tags" ]
+  }
+
+  # Get the bucket prefix from the S3 object key.
+  mutate {
+    copy => { "[aws][s3][object][key]" => "bucket_prefix" }
+  }
+  mutate {
+    lowercase => [ "bucket_prefix" ]
+    split => { "bucket_prefix" => "/" }
+  }
+  mutate {
+    rename => { "[bucket_prefix][0]" => "bucket_prefix" }
+  }
+  
+  # Set message_prefix to determine if the CloudWatch log includes a version and header.
+  ruby {
+    code => "event.set('message_prefix', event.get('message')[0,4])"
+  }
+  
+  if ( [message_prefix] == '#Ver' ) {
+    # Grok filter to convert multi-line CloudFront log from Beats into S3-type log format: cloudfront_version, cloudfront_fields and cloudfront_values
+    grok {
+      match => { "message" => "#Version: %{DATA:cloudfront_version}\n%{DATA:cloudfront_fields}\n%{GREEDYDATA:cloudfront_values}" }
+    }
+  } else {
+    mutate {
+      copy => { "message" => "cloudfront_values" }
+    }
+  }
+
+  # Grok filter to split the CloudFront log format, which is:
+  # Fields: date time x-edge-location sc-bytes c-ip cs-method cs(Host) cs-uri-stem sc-status cs(Referer) cs(User-Agent) cs-uri-query cs(Cookie) x-edge-result-type x-edge-request-id x-host-header cs-protocol cs-bytes time-taken x-forwarded-for ssl-protocol ssl-cipher x-edge-response-result-type cs-protocol-version fle-status fle-encrypted-fields c-port time-to-first-byte x-edge-detailed-result-type sc-content-type sc-content-len sc-range-start sc-range-end"
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#LogFileFormat
+  grok {
+    match => { "cloudfront_values" => "%{DATE_EU:date}\t%{TIME:time}\t%{DATA:x_edge_location}\t%{NONNEGINT:sc_bytes}\t%{IPORHOST:c_ip}\t%{WORD:cs_method}\t%{HOSTNAME:cs_host}\t%{NOTSPACE:cs_uri_stem}\t%{NONNEGINT:sc_status}\t%{DATA:cs_referrer}\t%{DATA:cs_user_agent}\t%{DATA:cs_uri_query}\t%{DATA:cs_cookie}\t%{WORD:x_edge_result_type}\t%{DATA:x_edge_request_id}\t%{HOSTNAME:x_host_header}\t%{URIPROTO:cs_protocol}\t%{NONNEGINT:cs_bytes}\t%{BASE10NUM:time_taken}\t%{DATA:x_forwarded_for}\t%{DATA:ssl_protocol}\t%{DATA:ssl_cipher}\t%{DATA:x_edge_response_result_type}\t%{DATA:cs_protocol_version}\t%{DATA:fle_status}\t%{DATA:fle_encrypted_fields}\t%{NONNEGINT:c-port}\t%{BASE10NUM:time_to_first_byte}\t%{DATA:x_edge_detailed_result_type}\t%{DATA:sc_content_type}\t%{DATA:sc_content_len}\t%{DATA:sc_range_start}\t%{GREEDYDATA:sc_range_end}" }
+  }
+
+  # Create clones for OpenSearch, Sentinel and SQS outputs.
+  clone {
+    clones => ['cloudwatch_to_opensearch', 'cloudwatch_to_sentinel', 'logstash_to_sqs' ]
+  }
+  # Drop the OpenSearch clone unless the object prefix is "elk"
+  if ( ([type] == 'cloudwatch_to_opensearch') and ( [bucket_prefix] != 'elk' ) ) {
+    drop { }
+  }
+  # Drop the SQS clone if there are no message headers (i.e. a multi-line log file).
+  if ( ([type] == 'logstash_to_sqs') and ( [message_prefix] != '#Ver' )  ) {
+    drop { }
+  }
+
+  if ( ([type] == 'cloudwatch_to_sentinel') or ([type] == 'cloudwatch_to_opensearch') or ([type] == 'logstash_to_sqs') ) {
+    # Remove fields added by Beats inputs that aren't required in any clones.
+    mutate {
+      remove_field => [ "log", "host", "cloud", "input", "agent", "ecs", "bucket_prefix" ]
+    }
+  }
+
+  if ( ([type] == 'cloudwatch_to_opensearch') or ([type] == 'cloudwatch_to_sentinel') ) {
+    # Remove fields added by Beats inputs that aren't required for Opensearch or Sentinel.
+    mutate {
+      remove_field => "message"
+    }
+  }
+
+  if ( ( [type] == 'cloudwatch_to_opensearch') or ([type] == 'logstash_to_sqs') ) {
+    # Remove fields added by filters that aren't required for Opensearch or SQS.
+    mutate {
+      remove_field => [ "cloudfront_values", "cloudfront_fields", "cloudfront_version" ]
+    }
+  }
+
+  if ([type] == 'logstash_to_sqs') {
+    # Remove fields added by filters that aren't required for SQS.# Remove fields added by filters that aren't required for SQS.
+    mutate {
+      remove_field => [ "x_forwarded_for", "date", "cs_referrer", "time_to_first_byte", "x_edge_request_id", "cs_cookie", "x_edge_response_result_type", "ssl_cipher", "sc_content_type", "x_edge_location", "cs_uri_stem", "sc_content_len", "cs_host", "cs_protocol_version", "cs_user_agent", "sc_range_end", "cs_method", "sc_bytes", "fle_status", "x_edge_result_type", "cs_bytes", "ssl_protocol", "time", "cs_protocol", "x_edge_detailed_result_type", "fle_encrypted_fields", "sc_range_start", "x_host_header", "c_ip", "c-port", "cs_uri_query", "time_taken", "sc_status" ]
+    }
+
+  }
+
+}
+
+
+output {
+
+  # Standard out for debugging in CloudWatch
+  stdout {}
+
+  if [type] == 'cloudwatch_to_opensearch' {
+    # Opensearch output
+    opensearch {
+      ssl => true
+      ssl_certificate_verification => true
+      manage_template => false
+      ecs_compatibility => disabled
+      user => "${ODFE_ELASTICSEARCH_USERNAME}"
+      password => "${ODFE_ELASTICSEARCH_PASSWORD}"
+      hosts => "${ODFE_ELASTICSEARCH_URL}"
+      index => "${AWS_CLOUDFRONT_ELASTICSEARCH_INDEX}"
+    }
+  }
+
+  if [type] == 'cloudwatch_to_sentinel' {
+    # Sentinel Output
+    microsoft-logstash-output-azure-loganalytics {
+      workspace_id => "${SENTINEL_WORKSPACE_ID}"
+      workspace_key => "${SENTINEL_WORKSPACE_KEY}"
+      custom_log_table_name => "${SENTINEL_WORKSPACE_TABLENAME_CLOUDFRONT}"
+    }
+  }
+
+  if [type] == 'logstash_to_sqs' {
+    # SQS output for S3 buclet pruning
+    sqs {
+      queue => "${SQS_OUTPUT_QUEUE}"
+      region => "${region}"
+    }
+  }
+
+}


### PR DESCRIPTION
Adds the following changes:
- Filebeat docker image to read from S3-SQS and forward to Logstash
- Logstash docker image to process CloudFront logs received from Filebeat and forward to Sentinel, OpenSearch and SQS.
- S3 Pruner docker image - this reads the processed files from the SQS queue written to by Logstash and deletes the log files from S3.