### PR TITLE
Add "cf-app-version-checker" to Sentinel

### DIFF
--- a/logstash-sentinel/pipelines/sentinel.conf
+++ b/logstash-sentinel/pipelines/sentinel.conf
@@ -87,7 +87,7 @@ filter {
         }
     }
 
-    if [cf][org] != "traderemedies-services" and [cf][space] != "market-access" and [cf][app] not in ["staff-sso","datahub-api","digital-workspace-v2","lite-hmrc","lite-api","lite-exporter-frontend","lite-internal-frontend","lite-hmrc-demo","lite-api-demo","lite-exporter-frontend-demo","lite-internal-frontend-demo","great-cms","clamav-rest"] {
+    if [cf][org] != "traderemedies-services" and [cf][space] != "market-access" and [cf][app] not in ["staff-sso","datahub-api","digital-workspace-v2","lite-hmrc","lite-api","lite-exporter-frontend","lite-internal-frontend","lite-hmrc-demo","lite-api-demo","lite-exporter-frontend-demo","lite-internal-frontend-demo","great-cms","clamav-rest","cf-app-version-checker"] {
       drop { }
     }
 }


### PR DESCRIPTION
Makes the following change:
- Adds `cf-app-version-checker` to the Sentinel list. This app can be used for testing log ingestion.
