### PR TITLE
Update Fluent image to Alpine

### DIFF
--- a/fluentd-public/Dockerfile
+++ b/fluentd-public/Dockerfile
@@ -1,9 +1,10 @@
-FROM fluent/fluentd:v1.15.3-debian-1.1
+FROM fluent/fluentd:v1.15.3-1.0
 
 USER root
 
-RUN apt-get update && \
-    apt-get install make gcc -y
+RUN apk update && \
+    apk upgrade && \
+    apk add make gcc
 
 RUN gem install google-protobuf -v 3.21.12 && \
     gem install fluent-plugin-kinesis -v 3.4.2


### PR DESCRIPTION
Makes the following changes:
- Update image base from Debian to Alpine
- Add `upgrade` step to remediate CVE-2021-33621 