### PR TITLE
Update Sentinel base image to version 7.17.8

### DIFF
--- a/logstash-sentinel/Dockerfile
+++ b/logstash-sentinel/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/logstash/logstash:7.15.0
+FROM docker.elastic.co/logstash/logstash:7.17.8
 
 RUN cd /usr/share/logstash && \
 				bin/logstash-plugin install logstash-codec-cloudwatch_logs && \


### PR DESCRIPTION
Makes the following update:
- Updates the base logstash image from `7.15.0` to `7.17.8`