### PR TITLE
Add ecs_compatibility config (removes warning).

### DIFF
--- a/logstash-sentinel/logstash.yml
+++ b/logstash-sentinel/logstash.yml
@@ -5,3 +5,4 @@ http.host: "0.0.0.0"
 
 dead_letter_queue.enable: false
 path.dead_letter_queue: "/usr/share/logstash/data/dead_letter_queue"
+pipeline.ecs_compatibility: disabled


### PR DESCRIPTION
Makes the following update:
- Updates the base logstash image to add `pipeline.ecs_compatibility: disabled`
- Removes the deprecation warning if this is not specified.