### PR TITLE
Disable stdout output.

### DIFF
--- a/logstash-sentinel-vpc/pipelines/sentinel_aws_vpc.conf
+++ b/logstash-sentinel-vpc/pipelines/sentinel_aws_vpc.conf
@@ -119,7 +119,7 @@ filter {
 output {
 
   # Standard out for debugging in CloudWatch.
-  stdout {}
+  # stdout {}
 
   # Sentinel Output where "data_tier" field exists.
   if ( [data_tier] == 'Basic' ) {


### PR DESCRIPTION
Applies a small change:
- comments out the `stdout {}` output line. Used only for development / debugging.