### PR TITLE
Logstash version and stdout output filter

### DIFF
--- a/logstash-cloudwatch-kinesis-sentinel/Dockerfile
+++ b/logstash-cloudwatch-kinesis-sentinel/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/logstash/logstash:8.15.0
+FROM docker.elastic.co/logstash/logstash:7.17.13
 
 RUN cd /usr/share/logstash && \
 		bin/logstash-plugin install logstash-codec-cloudwatch_logs && \

--- a/logstash-cloudwatch-kinesis-sentinel/Dockerfile
+++ b/logstash-cloudwatch-kinesis-sentinel/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/logstash/logstash:8.17.2
+FROM docker.elastic.co/logstash/logstash:8.15.0
 
 RUN cd /usr/share/logstash && \
 		bin/logstash-plugin install logstash-codec-cloudwatch_logs && \

--- a/logstash-cloudwatch-kinesis-sentinel/pipelines/cloudwatch_kinesis_sentinel.conf
+++ b/logstash-cloudwatch-kinesis-sentinel/pipelines/cloudwatch_kinesis_sentinel.conf
@@ -23,6 +23,11 @@ filter {
 }
 
 output {
+
+  # Standard out to CloudWatch
+  stdout {}
+
+  # Output to Sentinel
   microsoft-sentinel-log-analytics-logstash-output-plugin {
     client_app_Id => "${client_app_Id}"
     client_app_secret => "${client_app_secret}"
@@ -31,4 +36,5 @@ output {
     dcr_immutable_id => "${dcr_immutable_id}"
     dcr_stream_name => "${dcr_stream_name}"
   }
+
 }


### PR DESCRIPTION
Makes the following changes:
- Revert Logstash version from `8.17.2` to `7.17.13` (latest reliable version tested with the Sentinel output plugin)
- Add `stdout` to output filter block for logs to CloudWatch.

---

Logstash / Sentinel plugin compatibility is documented here: https://github.com/Azure/Azure-Sentinel/blob/master/DataConnectors/microsoft-sentinel-log-analytics-logstash-output-plugin/README.md