### PR TITLE
Add second sentinel output

### DIFF
--- a/logstash-sentinel-waf/pipelines/sentinel_waf.conf
+++ b/logstash-sentinel-waf/pipelines/sentinel_waf.conf
@@ -38,7 +38,7 @@ output {
   # stdout {}
 
   if [type] == 'waf_to_sentinel' {
-    # Sentinel Output
+    # Sentinel Output - Prod
     microsoft-sentinel-log-analytics-logstash-output-plugin {
       client_app_Id => "${SENTINEL_CLIENT_APP_ID}"
       client_app_secret => "${SENTINEL_CLIENT_APP_SECRET}"
@@ -47,6 +47,17 @@ output {
       dcr_immutable_id => "${SENTINEL_DCR_IMMUTABLE_ID}"
       dcr_stream_name => "${SENTINEL_DCR_STREAM_NAME}"
       create_sample_file=> false
+    }
+
+    # Sentinel Output - Non-Prod
+    microsoft-sentinel-log-analytics-logstash-output-plugin {
+      client_app_Id => "${SENTINEL_CLIENT_APP_ID}"
+      client_app_secret => "${SENTINEL_CLIENT_APP_SECRET}"
+      tenant_id => "${SENTINEL_TENANT_ID}"
+      data_collection_endpoint => "${SENTINEL_DATA_COLLECTION_ENDPOINT}"
+      dcr_immutable_id => "${SENTINEL_DCR_IMMUTABLE_ID_NONPROD}"
+      dcr_stream_name => "${SENTINEL_DCR_STREAM_NAME_NONPROD}"
+      create_sample_file => false
     }
   }
 


### PR DESCRIPTION
[SR-3498](https://uktrade.atlassian.net/browse/SR-3498)

Adding a secondary non-prod sentinel output to WAF logs as requested by Cyber. 

[SR-3498]: https://uktrade.atlassian.net/browse/SR-3498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ